### PR TITLE
Persist batch imported data in db

### DIFF
--- a/hydrogen/hydrogen.py
+++ b/hydrogen/hydrogen.py
@@ -1,16 +1,16 @@
 from importer import ArgsmeBatchImporter
 from log_config import setup_logging
 from config import Config
-# from database import Database
+from database import Database
 
 config = Config()
-# database = Database()
+database = Database()
 
 setup_logging('hydrogen.log')
 
 if __name__ == "__main__":
     config.initialize()
-    # database.initialize()
+    database.initialize()
 
     importer = ArgsmeBatchImporter('./importer/example_data/args-me.json')
     importer.batch_import()

--- a/hydrogen/importer/batch.py
+++ b/hydrogen/importer/batch.py
@@ -1,5 +1,6 @@
 from .lexer import ArgsmeLexer
 from .parser import ArgsmeParser
+from .emitter import Emitter
 from collections import deque
 from abc import ABC, abstractmethod
 import logging
@@ -11,11 +12,12 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: Investigate Stream-Based Processing and Filtering at Parse Time with ijson to improve performance
-
+# TODO: Remove not handling multiple batches tech debt, current implementation only works with 1 batch
 
 class BaseImporter(ABC):
     def __init__(self, file_path):
         self.file_path = file_path
+        self.emitter = Emitter()
 
     def get_file_path(self):
         return self.file_path
@@ -30,63 +32,57 @@ class BaseImporter(ABC):
 
 
 class ArgsmeBatchImporter(BaseImporter):
-    class Batch:
-        def __init__(self):
-            self.pending = deque()
-            self.completed = {}
-            self.failed = {}
-
-        def init_current_batch(self):
-            self.pending.clear()
-            self.completed.clear()
-            self.failed.clear()
-
-        def add_pending_argument(self, pending_arg):
-            src_id = pending_arg['context']['sourceId']
-            if src_id not in self.completed:
-                self.completed[src_id] = None
-            self.pending.append(pending_arg)
-
-        def get_completed_arguments(self):
-            return self.completed
-
-        def get_completed_argument(self, src_id):
-            return self.completed[src_id]
-
-        def has_pending(self):
-            return len(self.pending) > 0
-
-        def process(self):
-            while self.pending:
-                argument = self.pending.popleft()
-
-                try:
-                    lexer = ArgsmeLexer(json_data=argument)
-                    lexer.tokenize()
-                    tokens = lexer.get_lexed_tokens()
-
-                    parser = ArgsmeParser(batch=self, lexed_tokens=tokens)
-                    sadface = parser.parse()
-                    self.completed[sadface.get_id()] = sadface.document
-
-                except Exception as e:
-                    # TODO: Add to self.failed
-                    print(f"Failed processing document: {e}")
-
     def __init__(self, file_path, batch_size_bytes=1073741824):
         super().__init__(file_path)
         self.batch_size_bytes = batch_size_bytes  # 1GB
-        self.current_batch = self.Batch()
+        self.pending = deque()
+        self.completed = {}
+        self.failed = {}
+
+    def init_batch(self):
+        self.pending.clear()
+        self.completed.clear()
+        self.failed.clear()
+
+    def add_pending_argument(self, pending_arg):
+        src_id = pending_arg['context']['sourceId']
+        self.pending.append(pending_arg)
+
+        if src_id not in self.completed:
+            self.completed[src_id] = None
+
+    def get_completed_arguments(self):
+        return self.completed
+
+    def get_completed_argument(self, src_id):
+        return self.completed[src_id]
+
+    def has_pending(self):
+        return len(self.pending) > 0
+
+    def process(self):
+        while self.pending:
+            argument = self.pending.popleft()
+
+            try:
+                lexer = ArgsmeLexer(json_data=argument)
+                lexer.tokenize()
+                tokens = lexer.get_lexed_tokens()
+
+                parser = ArgsmeParser(batch=self, lexed_tokens=tokens)
+                sadface = parser.parse()
+                self.completed[sadface.get_id()] = sadface.document
+
+            except Exception as e:
+                # TODO: Add to self.failed
+                print(f"Failed processing document: {e}")
 
     def batch_import(self):
         if not os.path.exists(self.file_path):
             self.abort(f"File does not exist: {self.file_path}")
 
-        self.load_argsme_batches()
-
-    def load_argsme_batches(self):
+        self.init_batch()
         current_batch_size = 0
-        self.current_batch.init_current_batch()
 
         try:
             with open(self.file_path, 'rb') as file:
@@ -95,19 +91,27 @@ class ArgsmeBatchImporter(BaseImporter):
                 for argument in arguments:
                     argument_str = json.dumps(argument)
                     argument_size = len(argument_str.encode('utf-8'))
+                    new_batch = current_batch_size + argument_size > self.batch_size_bytes
 
-                    if current_batch_size + argument_size > self.batch_size_bytes:
-                        self.current_batch.process()
-                        self.current_batch.init_current_batch()
-                        self.current_batch.add_pending_argument(argument)
+                    if new_batch:
+                        self.process()
+                        self.init_batch()
+                        self.add_pending_argument(argument)
                         current_batch_size = argument_size
                     else:
-                        self.current_batch.add_pending_argument(argument)
+                        self.add_pending_argument(argument)
                         current_batch_size += argument_size
 
                 # Process any remaining
-                if self.current_batch.has_pending():
-                    self.current_batch.process()
+                if self.has_pending():
+                    self.process()
 
         except Exception as e:
             self.abort(f"Failed to load batches: {e}")
+
+        # Emmit completed batch to db
+        completed = self.get_completed_arguments()
+        for id, argument in completed.items():
+            self.emitter.set_uuid(id)
+            self.emitter.set_document(argument)
+            self.emitter.emit()

--- a/hydrogen/importer/emitter.py
+++ b/hydrogen/importer/emitter.py
@@ -1,25 +1,26 @@
 from database import Database, Raw
-import json 
+import json
 
 db = Database()
 
+
 class Emitter:
-  def __init__(self, uuid, doc):
-    self.document = doc
-    self.uuid = uuid
+    def __init__(self, uuid=None, doc=None):
+        self.document = doc
+        self.uuid = uuid
 
-  def set_uuid(self, uuid):
-    self.uuid = uuid
+    def set_uuid(self, uuid):
+        self.uuid = uuid
 
-  def set_document(self, doc):
-    self.document = doc
+    def set_document(self, doc):
+        self.document = doc
 
-  def emit(self):
-    result = db.raw.get(self.uuid)
-    
-    if result:
-      return db.raw.update(self.uuid, json.dumps(self.document))
-    
-    return db.raw.add(Raw(uuid=self.uuid, data=json.dumps(self.document)))
-    
-    
+    def emit(self):
+        exists = db.raw.get(uuid=self.uuid)
+        payload = json.dumps(self.document)
+
+        if exists:
+            return db.raw.update(uuid=self.uuid, payload=payload)
+
+        new_doc = Raw(uuid=self.uuid, data=payload)
+        return db.raw.add(payload=new_doc)

--- a/hydrogen/importer/lexer.py
+++ b/hydrogen/importer/lexer.py
@@ -32,7 +32,7 @@ class Lexer:
 
 
 class ArgsmeLexer(BaseLexer):
-    def __init__(self, json_data):
+    def __init__(self, json_data=None):
         super().__init__()
         self._json_data = json_data
         self._current_state = 'start'
@@ -58,6 +58,9 @@ class ArgsmeLexer(BaseLexer):
             'id': [ArgsmeToken.ID],
             'conclusion': [ArgsmeToken.CONCLUSION]
         }
+
+    def set_argument(self, json_data):
+        self._json_data = json_data
 
     def _process(self):
         next_state = self.STATE_TRANSITIONS.get(self._current_state)

--- a/hydrogen/importer/parser.py
+++ b/hydrogen/importer/parser.py
@@ -33,7 +33,7 @@ class Parser:
 
 
 class ArgsmeParser(BaseParser):
-    def __init__(self, batch, lexed_tokens):
+    def __init__(self, batch=None, lexed_tokens=None):
         super().__init__()
         self._builder = SadfaceBuilder()
         self._batch = batch
@@ -46,6 +46,12 @@ class ArgsmeParser(BaseParser):
             'meta_core': 'end',
             'build_edge': 'end'
         }
+
+    def set_batch(self, batch):
+        self._batch = batch
+
+    def set_tokens(self, lexed_tokens):
+        self._lexed_tokens = lexed_tokens
 
     def build_node(self):
         node = {


### PR DESCRIPTION
Changes

- Reinstated database initialisation in `main`, previously removed for performance checking
- Refactored database layer to only include `raw` table
- Added emitter to `batch.py`
- Removed `Batch()` subclass from `batch.py`
- Minor refactor of some methods in emitter, parser and lexer

Performance:

![Screenshot 2024-02-24 at 15 46 01](https://github.com/angus-dolan/argdb-hydrogen/assets/57960493/9640c45f-08c0-406a-976b-a5ac58e3781c)

- Lexing and parsing equate to around 16s runtime
- Writing to Sqlite is around 97s
- Giving a total importer runtime of around 113s